### PR TITLE
Add *HELP, *TYPE, *CLS, *MOUNT Commands

### DIFF
--- a/MOS.zdsproj
+++ b/MOS.zdsproj
@@ -29,6 +29,7 @@
 <file filter-key="">src\config.h</file>
 <file filter-key="">src\mos_api.inc</file>
 <file filter-key="flash">..\BBC Basic\Debug\BBC Basic.hex</file>
+<file filter-key="">src\strings.c</file>
 </files>
 
 <!-- configuration information -->

--- a/main.c
+++ b/main.c
@@ -54,7 +54,6 @@ extern char 			coldBoot;		// 1 = cold boot, 0 = warm boot
 extern volatile	char 	keycode;		// Keycode 
 extern volatile char	gp;				// General poll variable
 
-static FATFS 	fs;						// Handle for the file system
 static char  	cmd[256];				// Array for the command line handler
 
 // Wait for the ESP32 to respond with a GP packet to signify it is ready
@@ -128,7 +127,7 @@ int main(void) {
 	printf("@Baud Rate: %d\n\r\n\r", pUART0.baudRate);
 	#endif
 
-	f_mount(&fs, "", 1);							// Mount the SD card
+	(void)mos_mount();							// Mount the SD card
 
 	// Load the autoexec.bat config file
 	//

--- a/src/mos.c
+++ b/src/mos.c
@@ -45,6 +45,7 @@
 #include "uart.h"
 #include "clock.h"
 #include "ff.h"
+#include "strings.h"
 
 extern void *	set_vector(unsigned int vector, void(*handler)(void));	// In vectors16.asm
 
@@ -62,24 +63,25 @@ t_mosFileObject	mosFileObjects[MOS_maxOpenFiles];
 // Array of MOS commands and pointer to the C function to run
 //
 static t_mosCommand mosCommands[] = {
-	{ ".", 			&mos_cmdDIR		},
-	{ "DIR",		&mos_cmdDIR		},
-	{ "CAT",		&mos_cmdDIR		},
-	{ "LOAD",		&mos_cmdLOAD	},
-	{ "SAVE", 		&mos_cmdSAVE	},
-	{ "DELETE",		&mos_cmdDEL		},
-	{ "ERASE",		&mos_cmdDEL		},
-	{ "JMP",		&mos_cmdJMP		},
-	{ "RUN", 		&mos_cmdRUN		},
-	{ "CD", 		&mos_cmdCD		},
-	{ "RENAME",		&mos_cmdREN		},
-	{ "MOVE",		&mos_cmdREN		},
-	{ "MKDIR", 		&mos_cmdMKDIR	},
-	{ "COPY", 		&mos_cmdCOPY	},
-	{ "SET",		&mos_cmdSET		},
-	{ "VDU",		&mos_cmdVDU		},
-	{ "TIME", 		&mos_cmdTIME	},
-	{ "CREDITS",	&mos_cmdCREDITS	},
+	{ ".", 			&mos_cmdDIR,		HELP_CAT	},
+	{ "DIR",		&mos_cmdDIR,		HELP_CAT	},
+	{ "CAT",		&mos_cmdDIR,		HELP_CAT	},
+	{ "LOAD",		&mos_cmdLOAD,		HELP_LOAD	},
+	{ "SAVE", 		&mos_cmdSAVE,		HELP_SAVE	},
+	{ "DELETE",		&mos_cmdDEL,		HELP_DELETE	},
+	{ "ERASE",		&mos_cmdDEL,		HELP_DELETE	},
+	{ "JMP",		&mos_cmdJMP,		HELP_JMP	},
+	{ "RUN", 		&mos_cmdRUN,		HELP_RUN	},
+	{ "CD", 		&mos_cmdCD,		HELP_CD		},
+	{ "RENAME",		&mos_cmdREN,		HELP_RENAME	},
+	{ "MOVE",		&mos_cmdREN,		HELP_RENAME	},
+	{ "MKDIR", 		&mos_cmdMKDIR,		HELP_MKDIR	},
+	{ "COPY", 		&mos_cmdCOPY,		HELP_COPY	},
+	{ "SET",		&mos_cmdSET,		HELP_SET	},
+	{ "VDU",		&mos_cmdVDU,		HELP_VDU	},
+	{ "TIME", 		&mos_cmdTIME,		HELP_TIME	},
+	{ "CREDITS",		&mos_cmdCREDITS,	HELP_CREDITS	},
+	{ "HELP",		&mos_cmdHELP,		HELP_HELP	},
 };
 
 #define mosCommands_count (sizeof(mosCommands)/sizeof(t_mosCommand))
@@ -649,6 +651,40 @@ int mos_cmdCREDITS(char *ptr) {
 	printf("FabGL 1.0.8 (c) 2019-2022 by Fabrizio Di Vittorio\n\r");
 	printf("FatFS R0.14b (c) 2021 ChaN\n\r");
 	printf("\n\r");
+	return 0;
+}
+
+// HELP
+// Parameters:
+// - ptr: Pointer to the argument string in the line edit buffer
+// Returns:
+// -  0: success
+//   -1: command not found
+//
+int mos_cmdHELP(char *ptr) {
+	int i;
+	int found = 0;
+	char *cmd;
+
+	mos_parseString(NULL, &cmd);
+	if (cmd != NULL && strcasecmp(cmd, "all") == 0)
+		cmd = NULL;
+
+	for (i = 0; i < sizeof(mosCommands) / sizeof(mosCommands[0]); ++i) {
+		if (cmd == NULL)
+			printf("%s\r\n", mosCommands[i].help);
+		else
+			if (strcasecmp(cmd, mosCommands[i].name) == 0) {
+				printf("%s", mosCommands[i].help);
+				found = 1;
+			}
+	}
+
+	if (cmd != NULL && !found) {
+		printf("Error: '%s' not found\r\n", cmd);
+		return -1;
+	}
+
 	return 0;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -29,7 +29,7 @@
  * 26/03/2023:		Fixed SET KEYBOARD command
  * 14/04/2023:		Added fat_EOF
  * 15/04/2023:		Added mos_GETFIL, mos_FREAD, mos_FWRITE, mos_FLSEEK, refactored MOS file commands
- * 23/04/2023:		Added mos_cmdHELP, mos_cmdTYPE, mos_cmdCLS
+ * 23/04/2023:		Added mos_cmdHELP, mos_cmdTYPE, mos_cmdCLS, mos_cmdMOUNT, mos_mount
  */
 
 #include <eZ80.h>
@@ -57,6 +57,7 @@ extern volatile	BYTE keyascii;					// In globals.asm
 extern volatile	BYTE vpd_protocol_flags;		// In globals.asm
 extern BYTE 	rtc;							// In globals.asm
 
+static FATFS	fs;					// Handle for the file system
 static char * mos_strtok_ptr;	// Pointer for current position in string tokeniser
 
 t_mosFileObject	mosFileObjects[MOS_maxOpenFiles];
@@ -84,6 +85,7 @@ static t_mosCommand mosCommands[] = {
 	{ "CREDITS",		&mos_cmdCREDITS,	HELP_CREDITS	},
 	{ "TYPE",		&mos_cmdTYPE,		HELP_TYPE	},
 	{ "CLS",		&mos_cmdCLS,		HELP_CLS	},
+	{ "MOUNT",		&mos_cmdMOUNT,		HELP_MOUNT	},
 	{ "HELP",		&mos_cmdHELP,		HELP_HELP	},
 };
 
@@ -686,6 +688,21 @@ int	mos_cmdCLS(char *ptr) {
 	return 0;
 }
 
+// MOUNT
+// Parameters:
+// - ptr: Pointer to the argument string in the line edit buffer
+// Returns:
+// - MOS error code
+//
+int	mos_cmdMOUNT(char *ptr) {
+	int fr;
+
+	fr = mos_mount();
+	if (fr != FR_OK)
+		mos_error(fr);
+	return 0;
+}
+
 // HELP
 // Parameters:
 // - ptr: Pointer to the argument string in the line edit buffer
@@ -1235,3 +1252,14 @@ UINT8 fat_EOF(FIL * fp) {
 	}
 	return 0;
 }
+
+// (Re-)mount the MicroSD card
+// Parameters:
+// - None
+// Returns:
+// - fatfs error code
+//
+int mos_mount(void) {
+	return f_mount(&fs, "", 1);			// Mount the SD card
+}
+

--- a/src/mos.c
+++ b/src/mos.c
@@ -29,7 +29,7 @@
  * 26/03/2023:		Fixed SET KEYBOARD command
  * 14/04/2023:		Added fat_EOF
  * 15/04/2023:		Added mos_GETFIL, mos_FREAD, mos_FWRITE, mos_FLSEEK, refactored MOS file commands
- * 23/04/2023:		Added mos_cmdHELP, mos_cmdTYPE
+ * 23/04/2023:		Added mos_cmdHELP, mos_cmdTYPE, mos_cmdCLS
  */
 
 #include <eZ80.h>
@@ -83,6 +83,7 @@ static t_mosCommand mosCommands[] = {
 	{ "TIME", 		&mos_cmdTIME,		HELP_TIME	},
 	{ "CREDITS",		&mos_cmdCREDITS,	HELP_CREDITS	},
 	{ "TYPE",		&mos_cmdTYPE,		HELP_TYPE	},
+	{ "CLS",		&mos_cmdCLS,		HELP_CLS	},
 	{ "HELP",		&mos_cmdHELP,		HELP_HELP	},
 };
 
@@ -674,6 +675,16 @@ int mos_cmdTYPE(char * ptr) {
 	return fr;
 }
 
+// CLS
+// Parameters:
+// - ptr: Pointer to the argument string in the line edit buffer
+// Returns:
+// - MOS error code
+//
+int	mos_cmdCLS(char *ptr) {
+	putchar(12);
+	return 0;
+}
 
 // HELP
 // Parameters:

--- a/src/mos.h
+++ b/src/mos.h
@@ -26,7 +26,7 @@
  * 21/03/2023:		Added mos_SETINTVECTOR
  * 14/04/2023:		Added fat_EOF
  * 15/04/2023:		Added mos_GETFIL, mos_FREAD, mos_FWRITE, mos_FLSEEK
- * 24/05/2023:		Added mos_cmdHELP
+ * 24/05/2023:		Added mos_cmdHELP, mos_cmdTYPE
  */
 
 #ifndef MOS_H
@@ -74,10 +74,12 @@ int		mos_cmdSET(char *ptr);
 int		mos_cmdVDU(char *ptr);
 int		mos_cmdTIME(char *ptr);
 int		mos_cmdCREDITS(char *ptr);
+int		mos_cmdTYPE(char *ptr);
 int		mos_cmdHELP(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
+UINT24	mos_TYPE(char * filename);
 UINT24	mos_CD(char * path);
 UINT24	mos_DIR(char * path);
 UINT24	mos_DEL(char * filename);
@@ -163,6 +165,9 @@ UINT8	fat_EOF(FIL * fp);
 
 #define HELP_VDU	"*VDU <char1> <char2> ... <charN>\r\n"		\
 			"Write a stream of characters to the VDP\r\n"
+
+#define HELP_TYPE	"*TYPE <filename>\r\n"				\
+			"Display the contents of a file on the screen\r\n"
 
 #define HELP_HELP	"*HELP [ <command> | all ]\r\n"			\
 			"Display help on a single or all commands.\r\n"	\

--- a/src/mos.h
+++ b/src/mos.h
@@ -26,6 +26,7 @@
  * 21/03/2023:		Added mos_SETINTVECTOR
  * 14/04/2023:		Added fat_EOF
  * 15/04/2023:		Added mos_GETFIL, mos_FREAD, mos_FWRITE, mos_FLSEEK
+ * 24/05/2023:		Added mos_cmdHELP
  */
 
 #ifndef MOS_H
@@ -36,6 +37,7 @@
 typedef struct {
 	char * name;
 	int (*func)(char * ptr);
+	char * help;
 } t_mosCommand;
 
 typedef struct {
@@ -72,6 +74,7 @@ int		mos_cmdSET(char *ptr);
 int		mos_cmdVDU(char *ptr);
 int		mos_cmdTIME(char *ptr);
 int		mos_cmdCREDITS(char *ptr);
+int		mos_cmdHELP(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
@@ -100,5 +103,72 @@ UINT24	mos_SETINTVECTOR(UINT8 vector, UINT24 address);
 UINT24	mos_GETFIL(UINT8 fh);
 
 UINT8	fat_EOF(FIL * fp);
+
+#define HELP_CAT	"*CAT <path> (Aliases: DIR andd .)\r\n"		\
+			"Directory listing of the current directory.\r\n"
+
+#define HELP_CD		"*CD <path>\r\n"				\
+			"Change current directory\r\n"
+
+#define HELP_COPY	"*COPY <filename1> <filename2>\r\n"		\
+			"Create a copy of a file.\r\n"
+
+#define HELP_CREDITS	"*CREDITS\r\n"					\
+			"Output credits and version numbers for\r\n"	\
+			"third-party libraries used in the Agon firmware\r\n"
+
+#define HELP_DELETE	"*DELETE <filename> (Aliases: ERASE)\r\n"	\
+			"Delete a file or folder (must be empty).\r\n"
+
+#define HELP_JMP	"*JMP <addr>\r\n"				\
+			"Jump to the specified address in memory\r\n"
+
+#define HELP_LOAD	"*LOAD <filename> <addr>\r\n"			\
+			"Load a file from the SD card to the specified"	\
+			"address.\r\n"					\
+			"If no parameters are passed, then `addr' will"	\
+			"default to &40000.\r\n"
+
+#define HELP_MKDIR	"*MKDIR <filename>\r\n"				\
+			"Create a new folder on the SD card.\r\n"
+
+#define HELP_RENAME	"*RENAME <filename1> <filename2> "		\
+			"(Aliases: MOVE)\r\n"				\
+			"Rename a file in the same folder.\r\n"
+
+#define HELP_RUN	"*RUN <addr>\r\n"				\
+			"Call an executable binary loaded in memory.\r\n"\
+			"If no parameters are passed, then addr will "	\
+			"default to &40000.\r\n"
+
+#define HELP_SAVE	"*SAVE <filename> <addr> <size>\r\n"		\
+			"Save a block of memory to the SD card\r\n"
+
+#define HELP_SET	"*SET <option> <value>\r\n"			\
+			"Set a system option\r\n\r\n"			\
+			"Keyboard Layout\r\n"				\
+			"SET KEYBOARD n: Set the keyboard layout\r\n"	\
+			"    0: UK\r\n"					\
+			"    1: US\r\n"					\
+			"    2: German\r\n"				\
+			"    3: Italian\r\n"				\
+			"    4: Spanish\r\n"				\
+			"    5: French\r\n"				\
+			"    6: Belgian\r\n"				\
+			"    7: Norwegian\r\n"				\
+			"    8: Japanese\r\n"
+
+#define HELP_TIME	"*TIME [ <yyyy> <mm> <dd> <hh> <mm> <ss> ]\r\n"	\
+			"Set and read the ESP32 real-time clock\r\n"
+
+#define HELP_VDU	"*VDU <char1> <char2> ... <charN>\r\n"		\
+			"Write a stream of characters to the VDP\r\n"
+
+#define HELP_HELP	"*HELP [ <command> | all ]\r\n"			\
+			"Display help on a single or all commands.\r\n"	\
+			"List of commands:\r\n"				\
+			"CAT, CD, COPY, CREDITS, DELETE, JMP, \r\n"	\
+			"LOAD, MKDIR, RENAME, RUN, SAVE, SET, \r\n"	\
+			"TIME, VDU, HELP.\r\n"
 
 #endif MOS_H

--- a/src/mos.h
+++ b/src/mos.h
@@ -26,7 +26,7 @@
  * 21/03/2023:		Added mos_SETINTVECTOR
  * 14/04/2023:		Added fat_EOF
  * 15/04/2023:		Added mos_GETFIL, mos_FREAD, mos_FWRITE, mos_FLSEEK
- * 24/05/2023:		Added mos_cmdHELP, mos_cmdTYPE
+ * 24/05/2023:		Added mos_cmdHELP, mos_cmdTYPE, mos_cmdCLS
  */
 
 #ifndef MOS_H
@@ -75,6 +75,7 @@ int		mos_cmdVDU(char *ptr);
 int		mos_cmdTIME(char *ptr);
 int		mos_cmdCREDITS(char *ptr);
 int		mos_cmdTYPE(char *ptr);
+int		mos_cmdCLS(char *ptr);
 int		mos_cmdHELP(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
@@ -168,6 +169,9 @@ UINT8	fat_EOF(FIL * fp);
 
 #define HELP_TYPE	"*TYPE <filename>\r\n"				\
 			"Display the contents of a file on the screen\r\n"
+
+#define HELP_CLS	"*CLS\r\n"					\
+			"Clear the screen\r\n"
 
 #define HELP_HELP	"*HELP [ <command> | all ]\r\n"			\
 			"Display help on a single or all commands.\r\n"	\

--- a/src/mos.h
+++ b/src/mos.h
@@ -26,7 +26,7 @@
  * 21/03/2023:		Added mos_SETINTVECTOR
  * 14/04/2023:		Added fat_EOF
  * 15/04/2023:		Added mos_GETFIL, mos_FREAD, mos_FWRITE, mos_FLSEEK
- * 24/05/2023:		Added mos_cmdHELP, mos_cmdTYPE, mos_cmdCLS
+ * 24/05/2023:		Added mos_cmdHELP, mos_cmdTYPE, mos_cmdCLS, mos_cmdMOUNT
  */
 
 #ifndef MOS_H
@@ -56,6 +56,7 @@ char *	mos_strtok_r(char *s1, const char *s2, char **ptr);
 int		mos_exec(char * buffer);
 UINT8 	mos_execMode(UINT8 * ptr);
 
+int	mos_mount(void);
 
 BOOL 	mos_parseNumber(char * ptr, UINT24 * p_Value);
 BOOL	mos_parseString(char * ptr, char ** p_Value);
@@ -76,6 +77,7 @@ int		mos_cmdTIME(char *ptr);
 int		mos_cmdCREDITS(char *ptr);
 int		mos_cmdTYPE(char *ptr);
 int		mos_cmdCLS(char *ptr);
+int		mos_cmdMOUNT(char *ptr);
 int		mos_cmdHELP(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
@@ -173,11 +175,14 @@ UINT8	fat_EOF(FIL * fp);
 #define HELP_CLS	"*CLS\r\n"					\
 			"Clear the screen\r\n"
 
+#define HELP_MOUNT	"*MOUNT\r\n"					\
+			"(Re-)mount the MicroSD card\r\n"
+
 #define HELP_HELP	"*HELP [ <command> | all ]\r\n"			\
 			"Display help on a single or all commands.\r\n"	\
 			"List of commands:\r\n"				\
 			"CAT, CD, COPY, CREDITS, DELETE, JMP, \r\n"	\
 			"LOAD, MKDIR, RENAME, RUN, SAVE, SET, \r\n"	\
-			"TIME, VDU, HELP.\r\n"
+			"TIME, VDU, TYPE, CLS, MOUNT, HELP.\r\n"
 
 #endif MOS_H

--- a/src/mos.h
+++ b/src/mos.h
@@ -110,47 +110,47 @@ UINT24	mos_GETFIL(UINT8 fh);
 
 UINT8	fat_EOF(FIL * fp);
 
-#define HELP_CAT	"*CAT <path> (Aliases: DIR andd .)\r\n"		\
+#define HELP_CAT	"CAT <path> (Aliases: DIR andd .)\r\n"		\
 			"Directory listing of the current directory.\r\n"
 
-#define HELP_CD		"*CD <path>\r\n"				\
+#define HELP_CD		"CD <path>\r\n"				\
 			"Change current directory\r\n"
 
-#define HELP_COPY	"*COPY <filename1> <filename2>\r\n"		\
+#define HELP_COPY	"COPY <filename1> <filename2>\r\n"		\
 			"Create a copy of a file.\r\n"
 
-#define HELP_CREDITS	"*CREDITS\r\n"					\
+#define HELP_CREDITS	"CREDITS\r\n"					\
 			"Output credits and version numbers for\r\n"	\
 			"third-party libraries used in the Agon firmware\r\n"
 
-#define HELP_DELETE	"*DELETE <filename> (Aliases: ERASE)\r\n"	\
+#define HELP_DELETE	"DELETE <filename> (Aliases: ERASE)\r\n"	\
 			"Delete a file or folder (must be empty).\r\n"
 
-#define HELP_JMP	"*JMP <addr>\r\n"				\
+#define HELP_JMP	"JMP <addr>\r\n"				\
 			"Jump to the specified address in memory\r\n"
 
-#define HELP_LOAD	"*LOAD <filename> <addr>\r\n"			\
+#define HELP_LOAD	"LOAD <filename> <addr>\r\n"			\
 			"Load a file from the SD card to the specified"	\
 			"address.\r\n"					\
 			"If no parameters are passed, then `addr' will"	\
 			"default to &40000.\r\n"
 
-#define HELP_MKDIR	"*MKDIR <filename>\r\n"				\
+#define HELP_MKDIR	"MKDIR <filename>\r\n"				\
 			"Create a new folder on the SD card.\r\n"
 
-#define HELP_RENAME	"*RENAME <filename1> <filename2> "		\
+#define HELP_RENAME	"RENAME <filename1> <filename2> "		\
 			"(Aliases: MOVE)\r\n"				\
 			"Rename a file in the same folder.\r\n"
 
-#define HELP_RUN	"*RUN <addr>\r\n"				\
+#define HELP_RUN	"RUN <addr>\r\n"				\
 			"Call an executable binary loaded in memory.\r\n"\
 			"If no parameters are passed, then addr will "	\
 			"default to &40000.\r\n"
 
-#define HELP_SAVE	"*SAVE <filename> <addr> <size>\r\n"		\
+#define HELP_SAVE	"SAVE <filename> <addr> <size>\r\n"		\
 			"Save a block of memory to the SD card\r\n"
 
-#define HELP_SET	"*SET <option> <value>\r\n"			\
+#define HELP_SET	"SET <option> <value>\r\n"			\
 			"Set a system option\r\n\r\n"			\
 			"Keyboard Layout\r\n"				\
 			"SET KEYBOARD n: Set the keyboard layout\r\n"	\
@@ -164,22 +164,22 @@ UINT8	fat_EOF(FIL * fp);
 			"    7: Norwegian\r\n"				\
 			"    8: Japanese\r\n"
 
-#define HELP_TIME	"*TIME [ <yyyy> <mm> <dd> <hh> <mm> <ss> ]\r\n"	\
+#define HELP_TIME	"TIME [ <yyyy> <mm> <dd> <hh> <mm> <ss> ]\r\n"	\
 			"Set and read the ESP32 real-time clock\r\n"
 
-#define HELP_VDU	"*VDU <char1> <char2> ... <charN>\r\n"		\
+#define HELP_VDU	"VDU <char1> <char2> ... <charN>\r\n"		\
 			"Write a stream of characters to the VDP\r\n"
 
-#define HELP_TYPE	"*TYPE <filename>\r\n"				\
+#define HELP_TYPE	"TYPE <filename>\r\n"				\
 			"Display the contents of a file on the screen\r\n"
 
-#define HELP_CLS	"*CLS\r\n"					\
+#define HELP_CLS	"CLS\r\n"					\
 			"Clear the screen\r\n"
 
-#define HELP_MOUNT	"*MOUNT\r\n"					\
+#define HELP_MOUNT	"MOUNT\r\n"					\
 			"(Re-)mount the MicroSD card\r\n"
 
-#define HELP_HELP	"*HELP [ <command> | all ]\r\n"			\
+#define HELP_HELP	"HELP [ <command> | all ]\r\n"			\
 			"Display help on a single or all commands.\r\n"	\
 			"List of commands:\r\n"				\
 			"CAT, CD, COPY, CREDITS, DELETE, JMP, \r\n"	\

--- a/src/strings.c
+++ b/src/strings.c
@@ -1,0 +1,24 @@
+/*
+ * Title:			AGON MOS - Additional string functions
+ * Author:			Leigh Brown
+ * Created:			24/05/2023
+ * Last Updated:	24/05/2023
+ */
+ 
+#include <ctype.h>
+
+int strcasecmp(const char *s1, const char *s2)
+{
+	const unsigned char *p1 = (const unsigned char *)s1;
+	const unsigned char *p2 = (const unsigned char *)s2;
+	int result;
+
+	if (p1 == p2)
+		return 0;
+
+	while ((result = tolower (*p1) - tolower (*p2++)) == 0)
+		if (*p1++ == '\0')
+			break;
+	return result;
+}
+

--- a/src/strings.h
+++ b/src/strings.h
@@ -1,0 +1,15 @@
+/*
+ * Title:			AGON MOS - Additional string functions
+ * Author:			Leigh Brown
+ * Created:			24/05/2023
+ * Last Updated:	24/05/2023
+ *
+ * Modinfo:
+ */
+
+#ifndef STRINGS_H
+#define STRINGS_H
+
+extern int strcasecmp(const char *s1, const char *s2);
+
+#endif // STRINGS_H


### PR DESCRIPTION
In order to make a more comfortable MOS environment, I have added the following commands:
*HELP - Display help on commands
*TYPE - Like the equivalent DOS command, displays a text file on the console
*CLS - shortcut to VDU 12 (which not all users may be familiar with)
*MOUNT - Re-(mount) the MicroSD card

Happy for any feedback.