### PR TITLE
RTC can be disabled by user

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -21,7 +21,7 @@
 #include "clock.h"
 
 extern volatile BYTE vpd_protocol_flags;		// In globals.asm
-extern volatile BYTE rtcEnable;
+extern volatile BYTE rtc_enable;
 
 const char * rtc_days[7][2] = {	
 	{ "Sun", "Sunday" },
@@ -51,7 +51,7 @@ const char * rtc_months[12][2] = {
 // Request an update of the RTC from the ESP32
 //
 void rtc_update() {
-	if (!rtcEnable) 
+	if (!rtc_enable) 
 		return;
 	
 	vpd_protocol_flags &= 0xDF;	// Reset bit 5

--- a/src/clock.c
+++ b/src/clock.c
@@ -21,6 +21,7 @@
 #include "clock.h"
 
 extern volatile BYTE vpd_protocol_flags;		// In globals.asm
+extern volatile BYTE rtcEnable;
 
 const char * rtc_days[7][2] = {	
 	{ "Sun", "Sunday" },
@@ -50,6 +51,9 @@ const char * rtc_months[12][2] = {
 // Request an update of the RTC from the ESP32
 //
 void rtc_update() {
+	if (!rtcEnable) 
+		return;
+	
 	vpd_protocol_flags &= 0xDF;	// Reset bit 5
 
 	putch(23);					// Request the time from the ESP32

--- a/src/mos_api.inc
+++ b/src/mos_api.inc
@@ -155,6 +155,7 @@ sysvar_keydelay:	EQU	22h	; 2: Keyboard repeat delay
 sysvar_keyrate:		EQU	24h	; 2: Keyboard repeat reat
 sysvar_keyled:		EQU	26h	; 1: Keyboard LED status
 sysvar_scrMode:		EQU	27h	; 1: Screen mode
+sysvar_rtcEnable:	EQU 28h ; 1: Rtc enable flag
 	
 ; Flags for the VPD protocol
 ;

--- a/src/mos_api.inc
+++ b/src/mos_api.inc
@@ -155,7 +155,7 @@ sysvar_keydelay:	EQU	22h	; 2: Keyboard repeat delay
 sysvar_keyrate:		EQU	24h	; 2: Keyboard repeat reat
 sysvar_keyled:		EQU	26h	; 1: Keyboard LED status
 sysvar_scrMode:		EQU	27h	; 1: Screen mode
-sysvar_rtcEnable:	EQU 28h ; 1: Rtc enable flag
+sysvar_rtcEnable:	EQU	28h ; 1: Rtc enable flag
 	
 ; Flags for the VPD protocol
 ;

--- a/src/rtc.asm
+++ b/src/rtc.asm
@@ -14,7 +14,7 @@
 			DEFINE .STARTUP, SPACE = ROM
 			SEGMENT .STARTUP
 			
-			XREF _rtcEnable
+			XREF _rtc_enable
 							
 			XDEF	__init_rtc
 			XDEF	_init_rtc
@@ -25,7 +25,7 @@ __init_rtc:
 _init_rtc:		
 			PUSH AF
 			LD	A, 1
-			LD (_rtcEnable), A
+			LD (_rtc_enable), A
 			POP AF
 			RET
 

--- a/src/rtc.asm
+++ b/src/rtc.asm
@@ -13,6 +13,8 @@
 
 			DEFINE .STARTUP, SPACE = ROM
 			SEGMENT .STARTUP
+			
+			XREF _rtcEnable
 							
 			XDEF	__init_rtc
 			XDEF	_init_rtc
@@ -20,5 +22,10 @@
 ; Initialise the real time clock registers
 ;
 __init_rtc:
-_init_rtc:		RET
+_init_rtc:		
+			PUSH AF
+			LD	A, 1
+			LD (_rtcEnable), A
+			POP AF
+			RET
 

--- a/src_startup/globals.asm
+++ b/src_startup/globals.asm
@@ -17,6 +17,7 @@
 ; 29/03/2023:	Added serialFlags
 ; 14/04/2023:	Added scratchpad
 ; 19/05/2023	Added scrmode
+; 05/06/2023:	Added RTC enable flag
 
 			INCLUDE	"../src/equs.inc"
 			
@@ -45,6 +46,7 @@
 			XDEF	_keyrate 
 			XDEF 	_keyled
 			XDEF	_scrmode
+			XDEF	_rtcEnable
 
 			XDEF	_errno
 			XDEF 	_coldBoot
@@ -88,6 +90,7 @@ _keydelay:		DS	2		; + 22h: Keyboard repeat delay
 _keyrate:		DS	2		; + 24h: Keyboard repeat rate
 _keyled:		DS	1		; + 26h: Keyboard LED status
 _scrmode:		DS	1		; + 27h: Screen mode
+_rtcEnable:		DS  1		; + 28h: RTC enable status
 
 _errno:			DS 	3		; extern int _errno
 _coldBoot:		DS	1		; extern char _coldBoot

--- a/src_startup/globals.asm
+++ b/src_startup/globals.asm
@@ -46,7 +46,7 @@
 			XDEF	_keyrate 
 			XDEF 	_keyled
 			XDEF	_scrmode
-			XDEF	_rtcEnable
+			XDEF	_rtc_enable
 
 			XDEF	_errno
 			XDEF 	_coldBoot
@@ -90,7 +90,7 @@ _keydelay:		DS	2		; + 22h: Keyboard repeat delay
 _keyrate:		DS	2		; + 24h: Keyboard repeat rate
 _keyled:		DS	1		; + 26h: Keyboard LED status
 _scrmode:		DS	1		; + 27h: Screen mode
-_rtcEnable:		DS  1		; + 28h: RTC enable status
+_rtc_enable:	DS	1		; + 28h: RTC enable status
 
 _errno:			DS 	3		; extern int _errno
 _coldBoot:		DS	1		; extern char _coldBoot


### PR DESCRIPTION
Resolves: https://github.com/breakintoprogram/agon-mos/issues/69

I've added flag for disabling RTC fetch operation and make mos filesystem drivers terminal mode compatible