### PR TITLE
src/mos.c: mos_FCLOSE: fix small bug

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -896,7 +896,7 @@ UINT24 mos_FCLOSE(UINT8 fh) {
 	
 	if(fh > 0 && fh <= MOS_maxOpenFiles) {
 		i = fh - 1;
-		if(&mosFileObjects[i].free > 0) {
+		if(mosFileObjects[i].free > 0) {
 			fr = f_close(&mosFileObjects[i].fileObject);
 			mosFileObjects[i].free = 0;
 		}


### PR DESCRIPTION
Remove incorrect & operator from reference to mosFileObjects[i].free

I haven't experienced any actual issues from this problem but it definitely looks wrong to me.