### PR TITLE
mos_setkbvector OS call, so user programs can access VDP keyboard packets

### DIFF
--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -71,6 +71,7 @@
 			XREF	_sysvars
 			XREF	_scratchpad
 			XREF	_vpd_protocol_flags
+			XREF	_user_kbvector
 
 			XREF	_f_open			; In ff.c
 			XREF	_f_close
@@ -116,6 +117,7 @@ mos_api:		CP	80h			; Check if it is a FatFS command
 			DW	mos_api_fread		; 0x1A
 			DW	mos_api_fwrite		; 0x1B
 			DW	mos_api_flseek		; 0x1C
+			DW	mos_api_setkbvector	; 0x1D
 ;			
 $$:			AND	7Fh			; Else remove the top bit
 			CALL	SWITCH_A		; And switch on this table
@@ -619,6 +621,24 @@ mos_api_setintvector:	LD	A, E
 			POP	DE 
 			POP	DE
 			RET 
+			
+; Set a VDP keyboard packet receiver callback
+; C: If non-zero then set the top byte of HLU(callback address)  to MB (for ADL=0 callers)
+; HLU: Pointer to callback
+mos_api_setkbvector:
+		PUSH DE
+		XOR A
+		OR C				; If C!=0 set top byte (bits 16:23) to MB
+		JR Z, $F
+		LD	A, MB
+		CALL	SET_AHL24
+$$:	PUSH HL
+		POP DE
+		LD HL, _user_kbvector
+		LD (HL),DE
+		
+		POP DE
+		RET
 
 ; Open UART1
 ; IXU: Pointer to UART struct

--- a/src/mos_api.inc
+++ b/src/mos_api.inc
@@ -66,6 +66,7 @@ mos_getfil:		EQU	19h
 mos_fread:		EQU	1Ah
 mos_fwrite:		EQU	1Bh
 mos_flseek:		EQU	1Ch
+mos_setkbvector:	EQU	1Dh
 
 ; FatFS file access functions
 ;

--- a/src/vdp_protocol.asm
+++ b/src/vdp_protocol.asm
@@ -54,6 +54,8 @@
 			XREF	_vdp_protocol_len
 			XREF	_vdp_protocol_ptr
 			XREF	_vdp_protocol_data
+			
+			XREF	_user_kbvector
 
 			XREF	serial_TX
 			XREF	serial_RX
@@ -149,7 +151,19 @@ vdp_protocol_GP:	LD		A, (_vdp_protocol_data + 0)
 ; Keyboard Data
 ; Received after a keypress event in the VPD
 ;
-vdp_protocol_KEY:	LD		A, (_vdp_protocol_data + 0)	; ASCII key code
+vdp_protocol_KEY:
+			LD		HL, (_user_kbvector)				; If a user kbvector is set, call it
+			LD		DE, 0
+			OR		A
+			SBC		HL,DE
+			JR		Z, $F
+			LD		HL, $F
+			PUSH	HL										; Push return address from user routine
+			LD		HL, (_user_kbvector)
+			LD		DE, _vdp_protocol_data			; Pass kb packet address to user routine in DE (24-bit)
+			JP		(HL)
+$$:
+			LD		A, (_vdp_protocol_data + 0)	; ASCII key code
 			LD		(_keyascii), A
 			LD		A, (_vdp_protocol_data + 1)	; Key modifiers (SHIFT, ALT, etc)
 			LD		(_keymods), A

--- a/src_startup/globals.asm
+++ b/src_startup/globals.asm
@@ -58,6 +58,8 @@
 			XDEF	_vdp_protocol_ptr
 			XDEF	_vdp_protocol_data
 
+			XDEF	_user_kbvector
+
 			SEGMENT BSS		; This section is reset to 0 in cstartup.asm
 			
 _sysvars:					; Please make sure the sysvar offsets match those in mos_api.inc
@@ -121,7 +123,13 @@ _vdp_protocol_cmd:	DS	1		; Command
 _vdp_protocol_len:	DS	1		; Size of packet data
 _vdp_protocol_ptr:	DS	3		; Pointer into data
 _vdp_protocol_data:	DS	VDPP_BUFFERLEN
-		
+
+;
+; Userspace hooks
+;
+_user_kbvector: DS 3   ; Pointer to function
+
+
 			SECTION DATA		; This section is copied to RAM in cstartup.asm
 
 			END


### PR DESCRIPTION
This PR lets userspace programs have access to VDP keyboard packets, without having to override the whole uart0 interrupt. There is example code here: https://github.com/tomm/agon-mos/tree/main/bin

For BBC BASIC, INKEY with a negative argument (to perform a non-blocking lookup of key up/down state) is implemented using this mos_setkbvector call: https://github.com/tomm/agon-bbc-basic/tree/inkey-with-negative-arg