### PR TITLE
Fix timer0 setup overflow

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -37,7 +37,7 @@ unsigned short init_timer0(int interval, int clkdiv, unsigned char ctrlbits) {
 	}
 	ctl = (ctrlbits | clkbits);
 
-	rr = (unsigned short)((SysClkFreq / 100) / clkdiv) * interval;
+	rr = (unsigned short)((SysClkFreq / 1000) / clkdiv) * interval;
 
 	TMR0_CTL = 0x00;													// Disable the timer and clear all settings	
 	TMR0_RR_L = (unsigned char)(rr);


### PR DESCRIPTION
Noticed this while implementing the PRT timers for the Agon Light emulator --  the timer0 duration calculation is wrong, and overflows. The intended 10ms delays end up as ~40ms due to this.