### PR TITLE
Revert "Fix timer0 setup overflow"

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -38,7 +38,7 @@ unsigned short init_timer0(int interval, int clkdiv, unsigned char ctrlbits) {
 	}
 	ctl = (ctrlbits | clkbits);
 
-	rr = (unsigned short)((SysClkFreq / 1000) / clkdiv) * interval;
+	rr = (unsigned short)((SysClkFreq / 100) / clkdiv) * interval;
 
 	TMR0_CTL = 0x00;													// Disable the timer and clear all settings	
 	TMR0_RR_L = (unsigned char)(rr);


### PR DESCRIPTION
This reverts commit eede237fb720a4095f4bfdbc4bf2ac5e2ef11caa.

The timer0 setup change prevents an Olimex Agon Light 2 from booting, as noted in #83 