### PR TITLE
Multi-line command history

### DIFF
--- a/main.c
+++ b/main.c
@@ -56,6 +56,9 @@ extern char 			coldBoot;		// 1 = cold boot, 0 = warm boot
 extern volatile	char 	keycode;		// Keycode 
 extern volatile char	gp;				// General poll variable
 
+extern volatile BYTE history_no;
+extern volatile BYTE history_size;
+
 static FATFS 	fs;						// Handle for the file system
 static char  	cmd[256];				// Array for the command line handler
 
@@ -133,6 +136,8 @@ int main(void) {
 	f_mount(&fs, "", 1);							// Mount the SD card
 	
 	putch(7);										// Startup beep
+	history_no = 0;
+	history_size = 0;
 
 	// Load the autoexec.bat config file
 	//

--- a/src/mos.c
+++ b/src/mos.c
@@ -61,6 +61,8 @@ extern BYTE 	rtc;							// In globals.asm
 
 static char * mos_strtok_ptr;	// Pointer for current position in string tokeniser
 
+extern volatile BYTE history_no;
+
 t_mosFileObject	mosFileObjects[MOS_maxOpenFiles];
 
 // Array of MOS commands and pointer to the C function to run

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -13,6 +13,7 @@
 #define MOS_EDITOR_H
 
 #define cmd_historyWidth	255
+#define cmd_historyDepth	16
 
 UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
 

--- a/src_startup/globals.asm
+++ b/src_startup/globals.asm
@@ -66,6 +66,9 @@
 			XDEF	_vdp_protocol_data
 
 			XDEF	_user_kbvector
+			
+			XDEF	_history_no
+			XDEF	_history_size
 
 			SEGMENT BSS		; This section is reset to 0 in cstartup.asm
 			
@@ -141,6 +144,11 @@ _vdp_protocol_data:	DS	VDPP_BUFFERLEN
 ; Userspace hooks
 ;
 _user_kbvector: 	DS	3		; Pointer to keyboard function
+
+;Cmd history
+
+_history_no:		DS 1
+_history_size:		DS 1
 
 			SECTION DATA		; This section is copied to RAM in cstartup.asm
 


### PR DESCRIPTION
Adds multi-line command history to the MOS line editor, allowing the user to step thru up to their last 16 commands, rather than just the previous command.

Multi-line history is accessed via the up/down arrow keys.  When at the beginning of a line, up will replace the current buffer with the previous history entry.  When at the end of a line, down goes to next entry.  When editing a line that is spread across multiple rows up/down will move between rows.  If pressing up or down and not at the beginning/end of a command and the cursor cannot go up/down a row it will go to beginning/end of line.

First iteration of this was by @HeathenUK 