### PR TITLE
Proposed I2C driver and MOS API implementation

### DIFF
--- a/MOS.wsp
+++ b/MOS.wsp
@@ -4,3 +4,5 @@ ptn_Child1=Frames
 [WorkState_v1_2.Frames]
 ptn_Child1=ChildFrames
 
+[WorkState_v1_2.Frames.ChildFrames]
+

--- a/MOS.zdsproj
+++ b/MOS.zdsproj
@@ -30,6 +30,7 @@
 <file filter-key="">src\config.h</file>
 <file filter-key="">src\mos_api.inc</file>
 <file filter-key="">src\defines.h</file>
+<file filter-key="">src\i2c.c</file>
 </files>
 
 <!-- configuration information -->

--- a/main.c
+++ b/main.c
@@ -42,6 +42,7 @@
 #include "ff.h"
 #include "clock.h"
 #include "mos.h"
+#include "i2c.h"
 
 #define		MOS_version		1
 #define		MOS_revision 	4
@@ -51,6 +52,7 @@ extern void *	set_vector(unsigned int vector, void(*handler)(void));
 
 extern void 	vblank_handler(void);
 extern void 	uart0_handler(void);
+extern void 	i2c_handler(void);
 
 extern char 			coldBoot;		// 1 = cold boot, 0 = warm boot
 extern volatile	char 	keycode;		// Keycode 
@@ -98,6 +100,7 @@ int wait_ESP32(UART * pUART, UINT24 baudRate) {
 void init_interrupts(void) {
 	set_vector(PORTB1_IVECT, vblank_handler); 	// 0x32
 	set_vector(UART0_IVECT, uart0_handler);		// 0x18
+	set_vector(I2C_IVECT, i2c_handler);			// 0x1C
 }
 
 // The main loop

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -1,0 +1,155 @@
+/*
+ * Title:			AGON MOS - I2C code
+ * Author:			Jeroen Venema
+ * Created:			07/11/2023
+ * Last Updated:	10/11/2023
+ * 
+ * Modinfo:
+ */
+
+#include <ez80.h>
+#include "i2c.h"
+#include <defines.h>
+#include "timer.h"
+
+// Set I2C clock and sampling frequency
+void I2C_setfrequency(UINT8 id) {
+	switch(id) {
+		case(I2C_SPEED_115200):
+			I2C_CCR = (0x01<<3) | 0x03;	// 115.2KHz fast-mode (400KHz max), sampling at 4.6MHz
+			break;
+		case(I2C_SPEED_230400):
+			I2C_CCR = (0x01<<3) | 0x02;	// 230.4KHz fast-mode (400KHz max), sampling at 2.3Mhz
+			break;
+		case(I2C_SPEED_57600):
+		default:
+			I2C_CCR = (0x01<<3) | 0x04;	// 57.6KHz default standard-mode (100KHz max), sampling at 1.15Mhz
+	}
+}
+
+// Initializes the I2C bus
+void init_I2C(void) {
+	i2c_msg_size = 0;
+	CLK_PPD1 = CLK_PPD_I2C_OFF;			// Power Down I2C block before enabling it, avoid locking bug
+	I2C_CTL = I2C_CTL_ENAB;				// Enable I2C block, don't enable interrupts yet
+	I2C_setfrequency(0);
+	CLK_PPD1 = 0x0;						// Power up I2C block
+}
+
+// Internal function
+void I2C_handletimeout(void) {
+	// reset the interface
+	I2C_CTL = 0;
+	init_I2C();
+}
+
+// Open the I2C bus, register the driver interrupt
+// Parameters: None
+// Returns: None
+void mos_I2C_OPEN(UINT8 frequency) {
+	init_I2C();
+	I2C_setfrequency(frequency);
+}
+
+// Close the I2C bus, deregister the driver interrupt
+// Parameters: None
+// Returns: None
+void mos_I2C_CLOSE(void) {
+	CLK_PPD1 = CLK_PPD_I2C_OFF;			// Power Down I2C block
+	I2C_CTL &= ~(I2C_CTL_ENAB);			// Disable I2C block
+}
+
+// Write a number of bytes to an address on the I2C bus
+// Parameters:
+// - i2c_address: I2C address of the slave device
+// - size: number of bytes to write
+// - buffer: pointer to the first byte to write
+// Returns:
+// - 0 on success, or errorcode
+UINT8 mos_I2C_WRITE(UINT8 i2c_address, UINT8 size, char * buffer) {
+
+	// send maximum of 32 bytes in a single I2C transaction
+	if(size > I2C_MAX_BUFFERLENGTH) size = I2C_MAX_BUFFERLENGTH;
+	if(i2c_address > 127) return RET_NORESPONSE;
+	// wait for IDLE status
+	init_timer0(1, 16, 0x00);  		// 1ms timer for delay
+	enable_timer0(1);
+	while(i2c_role) {
+		// anything but IDLE (00)
+		if(get_timer0() > I2C_TIMEOUTMS) {
+			I2C_handletimeout();
+			enable_timer0(0);		// Disable timer
+			return RET_ARB_LOST;
+		}
+	}
+	enable_timer0(0);
+
+	i2c_msg_ptr = buffer;
+	i2c_msg_size = size;
+	i2c_role = I2C_MTX;			// MTX - Master Transmit Mode
+	i2c_error = RET_OK;
+	i2c_slave_rw = i2c_address << 1;	// shift one bit left, 0 on bit 0 == write action on I2C
+
+	I2C_CTL = I2C_CTL_IEN | I2C_CTL_ENAB | I2C_CTL_STA; // send start condition
+
+	init_timer0(1, 16, 0x00);  		// 1ms timer for delay
+	enable_timer0(1);
+	while(i2c_role == I2C_MTX) {	// while MTX
+		if(get_timer0() > I2C_TIMEOUTMS) {
+			I2C_handletimeout();
+			enable_timer0(0);		// Disable timer
+			return RET_DATA_NACK;
+		}
+	}
+
+	enable_timer0(0);				// Disable timer
+	return i2c_error;
+}
+
+// Read a number of bytes from an i2c_address on the I2C bus
+// Parameters:
+// - i2c_address: I2C address of the slave device
+// - size: number of bytes to read
+// - buffer: pointer to the first byte to read
+// Returns:
+// - 0 on success, or errorcode
+UINT8 mos_I2C_READ(UINT8 i2c_address, UINT8 size, char* buffer)
+{
+	if(size == 0) return 0;
+	if(i2c_address > 127) return RET_NORESPONSE;
+	// receive maximum of 32 bytes in a single I2C transaction
+	if(size > I2C_MAX_BUFFERLENGTH) size = I2C_MAX_BUFFERLENGTH;
+
+	// wait for IDLE status
+	init_timer0(1, 16, 0x00);  		// 1ms timer for delay
+	enable_timer0(1);
+	while(i2c_role) {
+		// anything but IDLE (00)
+		if(get_timer0() > I2C_TIMEOUTMS) {
+			I2C_handletimeout();
+			enable_timer0(0);		// Disable timer
+			return RET_ARB_LOST;
+		}
+	}
+	enable_timer0(0);
+	i2c_msg_ptr = buffer;
+	i2c_msg_size = size;
+	i2c_role = I2C_MRX;			// MRX mode
+	i2c_error = RET_OK;
+	i2c_slave_rw = (1<<0);				// receive bit 0
+	i2c_slave_rw |= i2c_address << 1;	// shift 7-bit address one bit left
+
+	I2C_CTL = I2C_CTL_IEN | I2C_CTL_ENAB | I2C_CTL_STA; // send start condition
+
+	init_timer0(1, 16, 0x00);  		// 1ms timer for delay
+	enable_timer0(1);
+	while(i2c_role == I2C_MRX) {
+		if(get_timer0() > I2C_TIMEOUTMS) {
+			I2C_handletimeout();
+			enable_timer0(0);		// Disable timer
+			return RET_ARB_LOST;
+		}
+	}
+	enable_timer0(0);				// Disable timer
+	return i2c_error;
+}

--- a/src/i2c.h
+++ b/src/i2c.h
@@ -1,0 +1,51 @@
+#ifndef _I2C_H_
+#define _I2C_H_
+
+#include <defines.h>
+
+
+extern volatile char	i2c_slave_rw;
+extern volatile char	i2c_error;
+extern volatile char	i2c_role;
+extern volatile UINT8	i2c_msg_size;
+extern volatile char *	i2c_msg_ptr;
+
+// I2C_CTL register bits
+#define I2C_CTL_IEN		(1<<7)
+#define I2C_CTL_ENAB	(1<<6)
+#define I2C_CTL_STA		(1<<5)
+#define I2C_CTL_STP		(1<<4)
+#define I2C_CTL_IFLG	(1<<3)
+#define I2C_CTL_AAK		(1<<2)
+
+// ez80 PPD register bits
+#define CLK_PPD_I2C_OFF	(1<<2)
+
+// I2C return codes to caller
+#define RET_OK			0x00
+#define RET_NORESPONSE	0x01
+#define RET_DATA_NACK	0x02
+#define RET_ARB_LOST	0x04
+#define RET_BUS_ERROR	0x08
+
+// I2C constants
+#define I2C_MAX_BUFFERLENGTH	32
+#define I2C_TIMEOUTMS			2000
+#define I2C_SPEED_57600			0x01
+#define I2C_SPEED_115200		0x02
+#define I2C_SPEED_230400		0x03
+
+// I2C role state
+#define I2C_IDLE				0x00
+#define I2C_MTX					0x01
+#define I2C_MRX					0x02
+#define I2C_SRX					0x04
+#define I2C_STX					0x08
+
+void init_I2C(void);
+void	mos_I2C_OPEN(UINT8 frequency);
+void	mos_I2C_CLOSE(void);
+UINT8	mos_I2C_WRITE(UINT8 i2c_address, UINT8 size, char * buffer);
+UINT8	mos_I2C_READ(UINT8 i2c_address, UINT8 size, char * buffer);
+
+#endif _I2C_H_

--- a/src/i2c.inc
+++ b/src/i2c.inc
@@ -1,0 +1,21 @@
+;* Return status codes to read/write caller
+RET_OK					.equ	00h	; ok - caller sets this at entry
+RET_NORESPONSE			.equ	01h	; address sent, nack received
+RET_DATA_NACK			.equ	02h ; data sent, nack received
+RET_ARB_LOST			.equ	04h ; arbitration lost
+RET_BUS_ERROR			.equ	08h ; Bus error
+
+;* I2C ROLE STATUS
+I2C_IDLE				.equ	00h
+I2C_MTX					.equ	01h
+I2C_MRX					.equ	02h
+I2C_SRX					.equ	04h
+I2C_STX					.equ	08h
+
+;* I2C_CTL bits
+I2C_CTL_IEN				.equ	10000000b
+I2C_CTL_ENAB			.equ	01000000b
+I2C_CTL_STA				.equ	00100000b
+I2C_CTL_STP				.equ	00010000b
+I2C_CTL_IFLG			.equ	00001000b
+I2C_CTL_AAK				.equ	00000100b

--- a/src/interrupts.asm
+++ b/src/interrupts.asm
@@ -7,9 +7,12 @@
 ; Modinfo:
 ; 09/03/2023:	No longer uses timer interrupt 0 for SD card timing
 ; 29/03/2023:	Added support for UART1
+; 10/11/2023:	Added support for I2C
 
 			INCLUDE	"macros.inc"
 			INCLUDE	"equs.inc"
+			INCLUDE "ez80f92.inc"
+			INCLUDE "i2c.inc"
 
 			.ASSUME	ADL = 1
 
@@ -18,7 +21,8 @@
 			
 			XDEF	_vblank_handler
 			XDEF	_uart0_handler
-			
+			XDEF	_i2c_handler
+
 			XREF	_clock
 			XREF	_vdp_protocol_data
 			
@@ -27,6 +31,12 @@
 			XREF	mos_api
 			XREF	vdp_protocol			
 			
+			XREF	_i2c_slave_rw
+			XREF	_i2c_error
+			XREF	_i2c_role
+			XREF	_i2c_msg_ptr
+			XREF	_i2c_msg_size
+
 ; AGON Vertical Blank Interrupt handler
 ;
 _vblank_handler:	DI
@@ -66,3 +76,212 @@ _uart0_handler:		DI
 			POP		AF
 			EI
 			RETI.L	
+
+; AGON I2C Interrupt handler
+;
+_i2c_handler:
+			DI
+			PUSH	AF
+			PUSH	HL
+			PUSH	DE
+			IN0		A, (I2C_SR)				; input I2C status register - switch case to this status value
+			AND		11111000b				; cancel lower 3 bits, so we can use RRA. This will save 1 T-state
+			RRA
+			RRA
+			RRA								; bits [7:3] contain the jumpvector
+			CALL	i2c_handle_sr_vector
+			; and switch on the vectors in this table
+			DW		i2c_case_buserror		; 00h
+			DW		i2c_case_master_start	; 08h
+			DW		i2c_case_invalid		; 10h
+			DW		i2c_case_aw_acked		; 18h
+			DW		i2c_case_aw_nacked		; 20h
+			DW		i2c_case_db_acked		; 28h
+			DW		i2c_case_db_nacked		; 30h
+			DW		i2c_case_arblost		; 38h
+			DW		i2c_case_mr_ar_ack		; 40h
+			DW		i2c_case_mr_ar_nack		; 48h
+			DW		i2c_case_mr_dbr_ack		; 50h
+			DW		i2c_case_mr_dbr_nack	; 58h
+			DW		i2c_case_toimplement	; 60h - slave
+			DW		i2c_case_toimplement	; 68h - slave
+			DW		i2c_case_toimplement	; 70h - slave
+			DW		i2c_case_toimplement	; 78h - slave
+			DW		i2c_case_toimplement	; 80h - slave
+			DW		i2c_case_toimplement	; 88h - slave
+			DW		i2c_case_toimplement	; 90h - slave
+			DW		i2c_case_toimplement	; 98h - slave
+			DW		i2c_case_toimplement	; A0h - slave
+			DW		i2c_case_toimplement	; A8h - slave
+			DW		i2c_case_toimplement	; B0h - slave
+			DW		i2c_case_toimplement	; B8h - slave
+			DW		i2c_case_toimplement	; C0h - slave
+			DW		i2c_case_toimplement	; C8h - slave
+			DW		i2c_case_toimplement	; D0h - 10bit I2C address
+			DW		i2c_case_toimplement	; D8h - 10bit I2C address
+			DW		i2c_case_invalid		; E0h
+			DW		i2c_case_invalid		; E8h
+			DW		i2c_case_invalid		; F0h
+			DW		i2c_case_invalid		; F8h - Should never produce an interrupt
+
+i2c_handle_sr_vector:
+			EX		(SP), HL	; Swap HL with the contents of the top of the stack
+			ADD		A, A		; Multiply A by two
+			ADD		A, L 
+			LD		L, A 
+			ADC		A, H
+			SUB		L
+			LD		H, A		; Add 8bit A to HL 
+			LD		A, (HL)		; Fetch vector adress from the table
+			INC		HL
+			LD		H, (HL)
+			LD		L, A
+			EX		(SP), HL	; Swap this new address back, restores HL
+			RET					; Return program control to this new address		
+
+i2c_case_buserror: ; 00h
+			LD		A, RET_BUS_ERROR
+			LD		(_i2c_error),A
+			
+			; perform software reset of the bus
+			XOR		A
+			OUT0	(I2C_SRR),A
+			LD		HL, _i2c_role
+			LD		A, I2C_IDLE	; READY state
+			LD		(HL),A
+
+			POP		DE
+			POP		HL
+			POP		AF
+			EI
+			RETI.L
+
+i2c_case_master_start:		; 08h
+i2c_case_master_repstart:	; 10h
+			LD		A, (_i2c_slave_rw)		; load slave address and r/w bit
+			OUT0	(I2C_DR), A		; store to I2C Data Register
+			LD		A, I2C_CTL_IEN | I2C_CTL_ENAB | I2C_CTL_AAK
+			OUT0	(I2C_CTL),A		; set to Control register
+
+			POP		DE
+			POP		HL
+			POP		AF
+			EI
+			RETI.L
+
+i2c_case_aw_acked:	; 18h
+i2c_case_db_acked:	; 28h
+			; Check size and size--
+			LD		A, (_i2c_msg_size)
+			OR		A
+			JR		Z, i2c_sendstop
+			DEC		A
+			LD		(_i2c_msg_size), A
+
+			; load pointer
+			LD		HL, _i2c_msg_ptr
+			LD		DE, HL
+			LD		HL, (HL)
+
+			; Load indexed byte from buffer
+			LD		A, (HL)
+
+			OUT0	(I2C_DR), A		; store to I2C Data Register
+			LD		A, I2C_CTL_IEN | I2C_CTL_ENAB | I2C_CTL_AAK
+			OUT0	(I2C_CTL),A		; set to Control register
+
+			INC		HL				; pointer++
+			EX		DE, HL
+			LD		(HL), DE
+
+			POP		DE
+			POP		HL
+			POP		AF
+			EI
+			RETI.L
+
+i2c_case_aw_nacked:	; 20h
+i2c_case_mr_ar_nack: ; 48h
+			LD		A, RET_NORESPONSE
+			LD		(_i2c_error),A
+			JP		i2c_sendstop
+			
+i2c_case_db_nacked:	; 30h
+			LD		A, RET_DATA_NACK
+			LD		(_i2c_error),A
+			JP 		i2c_sendstop
+
+i2c_case_arblost:	; 38h
+			LD		A, RET_ARB_LOST
+			LD		(_i2c_error),A
+			JP 		i2c_sendstop
+
+i2c_case_mr_dbr_ack: ; 50h
+			; calculate offset address into i2c_mbuffer
+			LD		HL, _i2c_msg_ptr
+			LD		DE, HL
+			LD		HL, (HL)
+
+			IN0		A,(I2C_DR)		; load byte from I2C Data Register
+			LD		(HL),A			; store in buffer at calculated index
+
+			INC		HL				; pointer++
+			EX		DE, HL
+			LD		(HL), DE
+;			; intentionally falling through to next case
+i2c_case_mr_ar_ack: ; 40h		
+			LD		A, (_i2c_msg_size)
+			CP		1					; last byte to receive?
+			JR		Z, $F
+
+			LD		A, I2C_CTL_IEN | I2C_CTL_ENAB | I2C_CTL_AAK	; reply with ACK
+			JR		$end
+$$:
+			LD		A, I2C_CTL_IEN | I2C_CTL_ENAB				; reply without ACK	
+$end:		OUT0	(I2C_CTL),A		; set to Control register
+			; size--
+			LD		A, (_i2c_msg_size)
+			DEC		A
+			LD		(_i2c_msg_size), A
+
+			POP		DE
+			POP		HL
+			POP		AF
+			EI
+			RETI.L
+			
+i2c_case_mr_dbr_nack: ; 58h
+			; load pointer
+			LD		HL, _i2c_msg_ptr
+			LD		HL, (HL)
+
+			IN0		A,(I2C_DR)			; load byte from I2C Data Register
+			LD		(HL),A				; store in buffer at calculated index
+						
+			JR		i2c_sendstop
+
+i2c_case_invalid:
+i2c_case_toimplement:
+i2c_sendstop:
+			; send stop first to go to idle state
+			LD		A, I2C_CTL_ENAB | I2C_CTL_STP			
+			OUT0	(I2C_CTL),A		; set to Control register			
+$$:
+			IN0		A,(I2C_CTL)
+			AND		I2C_CTL_STP		; STP bit still in place?
+			JR		NZ, $B
+			
+			; Release control of the bus
+			XOR		A				; all bits of I2C_CTL to 0
+			OUT0	(I2C_CTL),A		; set to Control register I2C_CTL
+			LD		HL, _i2c_role
+			LD		A, I2C_IDLE	; IDLE state
+			LD		(HL),A
+
+			POP		DE
+			POP		HL
+			POP		AF
+			EI
+			RETI.L
+	
+			END

--- a/src_startup/globals.asm
+++ b/src_startup/globals.asm
@@ -73,6 +73,12 @@
 
 			XDEF	_user_kbvector
 
+			XDEF	_i2c_slave_rw
+			XDEF	_i2c_error
+			XDEF	_i2c_role
+			XDEF	_i2c_msg_ptr
+			XDEF	_i2c_msg_size
+
 			SEGMENT BSS		; This section is reset to 0 in cstartup.asm
 			
 _sysvars:					; Please make sure the sysvar offsets match those in mos_api.inc
@@ -153,6 +159,14 @@ _vdp_protocol_data:	DS	VDPP_BUFFERLEN
 ; Userspace hooks
 ;
 _user_kbvector: 	DS	3		; Pointer to keyboard function
+
+;I2C
+_i2c_slave_rw:		DS	1					; 7bit slave address + R/W bit
+_i2c_error:			DS	1					; Error report to caller application
+_i2c_role:			DS	1					; I2C current state
+_i2c_msg_ptr:		DS	3					; pointer to the current buffer
+_i2c_msg_size:		DS	1					; (remaining) message size
+
 
 			SECTION DATA		; This section is copied to RAM in cstartup.asm
 


### PR DESCRIPTION
Hi!
This proposed driver for I2C has the following API to user programs:
mos_i2c_open - to open the channel with a given frequency id (57.6Khz, 115.200Khz, 230Khz)
mos_i2c_close - to close the channel
mos_i2c_write - to send a I2C datagram to a given slave address, with length and pointer to a send buffer
mos_i2c_read - to read a I2C datagram from a given slave address, with length and pointer to a read buffer

Currently, the following functional limitations apply to the driver:

7bit addressing only
32byte datagram length maximum, aligning with several Linux driver implementations
Master (write/read) role only. Talking to sensors and displays uses this mode, but configuring the Agon as an I2C slave is not yet implemented
2sec arbitration timeout on the channel, allowing very slow sensors to reply before the channel times out, while not locking up the Agon if a sensor borks.
I'll publish example code to use this driver interface a.s.a.p.