### PR TITLE
Add semicolon and hex notation support to the MOS VDU command

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -660,9 +660,8 @@ int mos_cmdVDU(char *ptr) {
         // Check for '0x' or '0X' prefix
         if (len > 2 && (value_str[0] == '0' && tolower(value_str[1] == 'x'))) {
             base = 16;
-            value_str += 2;
-            len -= 2;
         }
+		
         // Check for '&' prefix
         if (value_str[0] == '&') {
             base = 16;


### PR DESCRIPTION
Conscious decision to not support comma (rather than whitespace) delimited values, as this would increase code complexity and depth exponentially given the potential for whitespace, comma and semicolon to all act as a delimiter.