### PR TITLE
Add wildcard support to file and directory functions

### DIFF
--- a/src_fatfs/ffconf.h
+++ b/src_fatfs/ffconf.h
@@ -39,7 +39,7 @@
 /   3: f_lseek() function is removed in addition to 2. */
 
 
-#define FF_USE_FIND		0
+#define FF_USE_FIND		1
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 


### PR DESCRIPTION
Adds wildcard support to MOS DIR, COPY, MOVE/RENAME and DELETE commands.

As a consequence (and similar to MOS's own strtok implementation there are some basic strdup and strndup functions added to avoid lots of malloc spam.

This also requires FF_USE_FIND to be switched to 1, but this has had no measurable impact on performance or memory use.