### PR TITLE
Add tab completion for files and directories

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -171,16 +171,17 @@ UINT24 mos_input(char * buffer, int bufferLength) {
 // Returns:
 // - Function pointer, or 0 if command not found
 //
-void * mos_getCommand(char * ptr) {
+t_mosCommand *mos_getCommand(char * ptr) {
 	int	   i;
 	t_mosCommand * cmd;	
 	for(i = 0; i < mosCommands_count; i++) {
 		cmd = &mosCommands[i];
 		if(mos_cmp(cmd->name, ptr) == 0) {
-			return cmd->func;
+			//return cmd->func;
+			return cmd;
 		}
 	}
-	return 0;
+	return NULL;
 }
 
 // Case insensitive commpare with abbreviations
@@ -335,12 +336,14 @@ int mos_exec(char * buffer) {
 	int 	(*func)(char * ptr);
 	char	path[256];
 	UINT8	mode;
+	t_mosCommand *cmd;
 
 	ptr = mos_trim(buffer);
 	ptr = mos_strtok(ptr, " ");
 	if(ptr != NULL) {
-		func = mos_getCommand(ptr);
-		if(func != 0) {
+		cmd = mos_getCommand(ptr);
+		func = cmd->func;
+		if(cmd != NULL && func != 0) {
 			fr = func(ptr);
 		}
 		else {		

--- a/src/mos.h
+++ b/src/mos.h
@@ -53,7 +53,7 @@ void 	mos_error(int error);
 
 BYTE	mos_getkey(void);
 UINT24	mos_input(char * buffer, int bufferLength);
-void *	mos_getCommand(char * ptr);
+t_mosCommand	*mos_getCommand(char * ptr);
 BOOL 	mos_cmp(char *p1, char *p2);
 char *	mos_trim(char * s);
 char *	mos_strtok(char *s1, char * s2);

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -380,7 +380,6 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									int pathLength = 1;
 																		
 									if (lastSpace != NULL && lastSlash > lastSpace) {
-										lastSpace++;
 										pathLength = lastSlash - lastSpace; // Path starts after the last space and includes the slash
 									}
 									if (lastSpace == NULL) {
@@ -393,7 +392,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									if (path == NULL) {
 										break;
 									}
-									strncpy(path, lastSpace, pathLength); // Start after the last space
+									strncpy(path, lastSpace + 1, pathLength); // Start after the last space
 									path[pathLength] = '\0'; // Null-terminate the string
 
 									// Determine the start of the search term

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -334,6 +334,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								FRESULT fr;
 								DIR dj;
 								FILINFO fno;
+								t_mosCommand *cmd;
 								const char *searchTermStart;
 								const char *lastSpace = strrchr(buffer, ' ');
 								const char *lastSlash = strrchr(buffer, '/');
@@ -341,12 +342,27 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								if (lastSlash == NULL && lastSpace == NULL) { //Try commands first before fatfs completion
 									
 									search_term = (char*) malloc(strlen(buffer) + 6);
+									
+									strcpy(search_term, buffer);
+									strcat(search_term, ".");
+									
+									cmd = mos_getCommand(search_term);
+									if (cmd != NULL) { //First try internal MOS commands
+										
+										printf("%s ", cmd->name + strlen(buffer));
+										strcat(buffer, cmd->name + strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);										
+										break;
+										
+									}
+									
 									strcpy(search_term, buffer);
 									strcat(search_term, "*.bin");
-									
 									fr = f_findfirst(&dj, &fno, "/mos/", search_term);
-									
-									if (fr == FR_OK && fno.fname[0]) {
+									if (fr == FR_OK && fno.fname[0]) { //Now try MOSlets
 										
 										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
 										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -338,7 +338,28 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								const char *lastSpace = strrchr(buffer, ' ');
 								const char *lastSlash = strrchr(buffer, '/');
 								
-
+								if (lastSlash == NULL && lastSpace == NULL) { //Try commands first before fatfs completion
+									
+									search_term = (char*) malloc(strlen(buffer) + 6);
+									strcpy(search_term, buffer);
+									strcat(search_term, "*.bin");
+									
+									fr = f_findfirst(&dj, &fno, "/mos/", search_term);
+									
+									if (fr == FR_OK && fno.fname[0]) {
+										
+										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
+										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);
+										break;
+										
+									}
+									
+								}
+								
 								if (lastSlash != NULL) {
 									int pathLength = 1;
 																		

--- a/src_fatfs/ffconf.h
+++ b/src_fatfs/ffconf.h
@@ -39,7 +39,7 @@
 /   3: f_lseek() function is removed in addition to 2. */
 
 
-#define FF_USE_FIND		0
+#define FF_USE_FIND		1
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 


### PR DESCRIPTION
As for wildcard support in DIR etc., this requires FF_USE_FIND to be enabled (and as mentioned in the other PR, this has no measurable impact on performance or memory usage). As this hooks into the mos_EDITLINE scheme it also works in BASIC and this is taken advantage of in allowing double quotes to be taken as the start of the section to be tab completed as well as whitespace (i.e. you can tab complete a file in a `LOAD ""` call in BASIC).