### PR TITLE
Add KEY hotkey command setting, calling, and clearing.

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -428,9 +428,10 @@ int mos_cmdKEY(char *ptr) {
 
 	if (!mos_parseNumber(NULL, &fn_number)) {
 		
+		UINT8 key;
 		printf("Hotkey assignments:\r\n\r\n");
 		
-		for (int key = 0; key < 12; key++) {
+		for (key = 0; key < 12; key++) {
 				printf("F%d: %s\r\n", key+1, hotkey_strings[key] == NULL ? "N/A" : hotkey_strings[key]);
 		}
 				

--- a/src/mos.c
+++ b/src/mos.c
@@ -430,30 +430,9 @@ int mos_cmdKEY(char *ptr) {
 		
 		printf("Hotkey assignments:\r\n\r\n");
 		
-		if (hotkey_strings[0] != NULL) printf("F1:  %s\r\n", hotkey_strings[0]);
-			else printf("F1:  N/A\r\n");
-		if (hotkey_strings[1] != NULL) printf("F2:  %s\r\n", hotkey_strings[1]);
-			else printf("F2:  N/A\r\n");
-		if (hotkey_strings[2] != NULL) printf("F3:  %s\r\n", hotkey_strings[2]);
-			else printf("F3:  N/A\r\n");
-		if (hotkey_strings[3] != NULL) printf("F4:  %s\r\n", hotkey_strings[3]);
-			else printf("F4:  N/A\r\n");
-		if (hotkey_strings[4] != NULL) printf("F5:  %s\r\n", hotkey_strings[4]);
-			else printf("F5:  N/A\r\n");
-		if (hotkey_strings[5] != NULL) printf("F6:  %s\r\n", hotkey_strings[5]);
-			else printf("F6:  N/A\r\n");
-		if (hotkey_strings[6] != NULL) printf("F7:  %s\r\n", hotkey_strings[6]);
-			else printf("F7:  N/A\r\n");
-		if (hotkey_strings[7] != NULL) printf("F8:  %s\r\n", hotkey_strings[7]);
-			else printf("F8:  N/A\r\n");
-		if (hotkey_strings[8] != NULL) printf("F9:  %s\r\n", hotkey_strings[8]);
-			else printf("F9:  N/A\r\n");
-		if (hotkey_strings[9] != NULL) printf("F10: %s\r\n", hotkey_strings[9]);
-			else printf("F10: N/A\r\n");
-		if (hotkey_strings[10] != NULL) printf("F11: %s\r\n", hotkey_strings[10]);
-			else printf("F11: N/A\r\n");
-		if (hotkey_strings[11] != NULL) printf("F12: %s\r\n", hotkey_strings[11]);
-			else printf("F12: N/A\r\n");
+		for (int key = 0; key < 12; key++) {
+				printf("F%d: %s\r\n", key+1, hotkey_strings[key] == NULL ? "N/A" : hotkey_strings[key]);
+		}
 				
 		printf("\r\n");
 		return 0;

--- a/src/mos.h
+++ b/src/mos.h
@@ -84,6 +84,7 @@ int		mos_cmdTYPE(char *ptr);
 int		mos_cmdCLS(char *ptr);
 int		mos_cmdMOUNT(char *ptr);
 int		mos_cmdHELP(char *ptr);
+int		mos_cmdKEY(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
@@ -192,6 +193,14 @@ UINT8	fat_EOF(FIL * fp);
 
 #define HELP_TYPE			"Display the contents of a file on the screen\r\n"
 #define HELP_TYPE_ARGS		"<filename>"
+
+#define HELP_KEY			"Store a command in one of 12 hotkey slots assigned to F1-F12\r\n\r\n" \
+							"Optionally, the command string can include \"%s\" as a marker\r\n" \
+							"in which case the hotkey command will be built either side.\r\n\r\n" \
+							"KEY without any arguments will list the currently assigned\r\n" \
+							"command strings.\r\n"
+							
+#define HELP_KEY_ARGS		"<key number> <command string>\r\n"
 
 #define HELP_CLS			"Clear the screen\r\n"
 

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -17,4 +17,6 @@
 
 UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
 
+extern char	*hotkey_strings[12];
+
 #endif MOS_EDITOR_H


### PR DESCRIPTION
This adds a KEY command that permits the user to assign a string to any of the F1-F12 keys. The string can optionally include a %s token and if it does the resulting command will include in this position whatever was already on the editor line (for example `load %s` (for MOS) or `LOAD "%S"` (for BASIC) would allow you to quickly load a file (particularly if coupled with tab completion in [PR 120](https://github.com/breakintoprogram/agon-mos/pull/120).

Requires a 256 byte buffer that holds an untokenized command string.