### PR TITLE
Add an equivalent to /mos/ called /bin/ which loads into and then executes from 0x040000

### DIFF
--- a/main.c
+++ b/main.c
@@ -154,7 +154,7 @@ int main(void) {
 	//
 	while(1) {
 		if(mos_input(&cmd, sizeof(cmd)) == 13) {
-			int err = mos_exec(&cmd);
+			int err = mos_exec(&cmd, TRUE);
 			if(err > 0) {
 				mos_error(err);
 			}

--- a/src/mos.c
+++ b/src/mos.c
@@ -363,7 +363,26 @@ int mos_exec(char * buffer) {
 							fr = 21;
 							break;
 					}
+					return fr;
 				}
+
+				sprintf(path, "/bin/%s.bin", ptr);
+				fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
+				if(fr == 0) {
+					mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
+					switch(mode) {
+						case 0:		// Z80 mode
+							fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
+							break;
+						case 1: 	// ADL mode
+							fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
+							break;	
+						default:	// Unrecognised header
+							fr = 21;
+							break;
+					}
+					return fr;
+				}				
 				else {
 					if(fr == 4) {
 						fr = 20;

--- a/src/mos.h
+++ b/src/mos.h
@@ -58,7 +58,7 @@ BOOL 	mos_cmp(char *p1, char *p2);
 char *	mos_trim(char * s);
 char *	mos_strtok(char *s1, char * s2);
 char *	mos_strtok_r(char *s1, const char *s2, char **ptr);
-int		mos_exec(char * buffer);
+int		mos_exec(char * buffer, BOOL in_mos);
 UINT8 	mos_execMode(UINT8 * ptr);
 
 int		mos_mount(void);


### PR DESCRIPTION
Either this or implementing a MOS equivalent to `CHAIN` are pretty necessary to remove one of the main snagging points for non-BASIC exclusive and non-technical Agon users. I prefer this option though recognise it has drawbacks, principally: users may put moslets compiled for 0x0B0000 in /bin/ or vice versa, and if called via existing code (e.g. from `OSCLI`) the user will almost certainly cause a crash.

This isn't any more confusing for the average user than the current situation and can be much more easily explained in a release: "this program should be put in /mos" or "this program should be put in /bin" is much more familiar and consistent for casual users than "this program needs to be put on your sd, loaded and then run, unless it's a moslet in which case it goes in /mos".