### PR TITLE
Tab completion and OSCLI-safe local/global loading and execution of non-MOSlet .bins

### DIFF
--- a/main.c
+++ b/main.c
@@ -154,7 +154,7 @@ int main(void) {
 	//
 	while(1) {
 		if(mos_input(&cmd, sizeof(cmd)) == 13) {
-			int err = mos_exec(&cmd);
+			int err = mos_exec(&cmd, TRUE);
 			if(err > 0) {
 				mos_error(err);
 			}

--- a/src/mos.c
+++ b/src/mos.c
@@ -330,7 +330,7 @@ BOOL mos_parseString(char * ptr, char ** p_Value) {
 // Returns:
 // - MOS error code
 //
-int mos_exec(char * buffer) {
+int mos_exec(char * buffer, BOOL in_mos) {
 	char * 	ptr;
 	int 	fr = 0;
 	int 	(*func)(char * ptr);
@@ -369,22 +369,44 @@ int mos_exec(char * buffer) {
 					return fr;
 				}
 
-				sprintf(path, "/bin/%s.bin", ptr);
-				fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
-				if(fr == 0) {
-					mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
-					switch(mode) {
-						case 0:		// Z80 mode
-							fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
-							break;
-						case 1: 	// ADL mode
-							fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
-							break;	
-						default:	// Unrecognised header
-							fr = 21;
-							break;
+				if (in_mos) {
+				
+					sprintf(path, "%s.bin", ptr);
+					fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
+					if(fr == 0) {
+						mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
+						switch(mode) {
+							case 0:		// Z80 mode
+								fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
+								break;
+							case 1: 	// ADL mode
+								fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
+								break;	
+							default:	// Unrecognised header
+								fr = 21;
+								break;
+						}
+						return fr;
+					}				
+					
+					sprintf(path, "/bin/%s.bin", ptr);
+					fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
+					if(fr == 0) {
+						mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
+						switch(mode) {
+							case 0:		// Z80 mode
+								fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
+								break;
+							case 1: 	// ADL mode
+								fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
+								break;	
+							default:	// Unrecognised header
+								fr = 21;
+								break;
+						}
+						return fr;
 					}
-					return fr;
+
 				}				
 				else {
 					if(fr == 4) {
@@ -1046,7 +1068,7 @@ UINT24 mos_BOOT(char * filename, char * buffer, UINT24 size) {
 	if(fr == FR_OK) {
 		while(!f_eof(&fil)) {
 			f_gets(buffer, size, &fil);
-			mos_exec(buffer);
+			mos_exec(buffer, TRUE);
 		}
 	}
 	f_close(&fil);	
@@ -1232,7 +1254,7 @@ void mos_GETERROR(UINT8 errno, UINT24 address, UINT24 size) {
 //
 UINT24 mos_OSCLI(char * cmd) {
 	UINT24 fr;
-	fr = mos_exec(cmd);
+	fr = mos_exec(cmd, FALSE);
 	return fr;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -366,7 +366,26 @@ int mos_exec(char * buffer) {
 							fr = 21;
 							break;
 					}
+					return fr;
 				}
+
+				sprintf(path, "/bin/%s.bin", ptr);
+				fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
+				if(fr == 0) {
+					mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
+					switch(mode) {
+						case 0:		// Z80 mode
+							fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
+							break;
+						case 1: 	// ADL mode
+							fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
+							break;	
+						default:	// Unrecognised header
+							fr = 21;
+							break;
+					}
+					return fr;
+				}				
 				else {
 					if(fr == 4) {
 						fr = 20;

--- a/src/mos.c
+++ b/src/mos.c
@@ -171,16 +171,17 @@ UINT24 mos_input(char * buffer, int bufferLength) {
 // Returns:
 // - Function pointer, or 0 if command not found
 //
-void * mos_getCommand(char * ptr) {
+t_mosCommand *mos_getCommand(char * ptr) {
 	int	   i;
 	t_mosCommand * cmd;	
 	for(i = 0; i < mosCommands_count; i++) {
 		cmd = &mosCommands[i];
 		if(mos_cmp(cmd->name, ptr) == 0) {
-			return cmd->func;
+			//return cmd->func;
+			return cmd;
 		}
 	}
-	return 0;
+	return NULL;
 }
 
 // Case insensitive commpare with abbreviations
@@ -335,12 +336,14 @@ int mos_exec(char * buffer) {
 	int 	(*func)(char * ptr);
 	char	path[256];
 	UINT8	mode;
+	t_mosCommand *cmd;
 
 	ptr = mos_trim(buffer);
 	ptr = mos_strtok(ptr, " ");
 	if(ptr != NULL) {
-		func = mos_getCommand(ptr);
-		if(func != 0) {
+		cmd = mos_getCommand(ptr);
+		func = cmd->func;
+		if(cmd != NULL && func != 0) {
 			fr = func(ptr);
 		}
 		else {		

--- a/src/mos.h
+++ b/src/mos.h
@@ -58,7 +58,7 @@ BOOL 	mos_cmp(char *p1, char *p2);
 char *	mos_trim(char * s);
 char *	mos_strtok(char *s1, char * s2);
 char *	mos_strtok_r(char *s1, const char *s2, char **ptr);
-int		mos_exec(char * buffer);
+int		mos_exec(char * buffer, BOOL in_mos);
 UINT8 	mos_execMode(UINT8 * ptr);
 
 int		mos_mount(void);

--- a/src/mos.h
+++ b/src/mos.h
@@ -53,7 +53,7 @@ void 	mos_error(int error);
 
 BYTE	mos_getkey(void);
 UINT24	mos_input(char * buffer, int bufferLength);
-void *	mos_getCommand(char * ptr);
+t_mosCommand	*mos_getCommand(char * ptr);
 BOOL 	mos_cmp(char *p1, char *p2);
 char *	mos_trim(char * s);
 char *	mos_strtok(char *s1, char * s2);

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -380,7 +380,6 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									int pathLength = 1;
 																		
 									if (lastSpace != NULL && lastSlash > lastSpace) {
-										lastSpace++;
 										pathLength = lastSlash - lastSpace; // Path starts after the last space and includes the slash
 									}
 									if (lastSpace == NULL) {
@@ -393,7 +392,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									if (path == NULL) {
 										break;
 									}
-									strncpy(path, lastSpace, pathLength); // Start after the last space
+									strncpy(path, lastSpace + 1, pathLength); // Start after the last space
 									path[pathLength] = '\0'; // Null-terminate the string
 
 									// Determine the start of the search term

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -372,10 +372,11 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 										free(search_term);
 										break;
 										
-									} else { //Otherwise try /bin/
-										
-										fr = f_findfirst(&dj, &fno, "/bin/", search_term);
-										if (!(fr == FR_OK && fno.fname[0])) break;
+									}
+									
+									//Try local .bin
+									fr = f_findfirst(&dj, &fno, "", search_term);
+									if ((fr == FR_OK && fno.fname[0])) {
 										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
 										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
 										strcat(buffer, " ");
@@ -383,8 +384,20 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 										insertPos = strlen(buffer);										
 										free(search_term);
 										break;									
-										
+									}									
+									
+									//Otherwise try /bin/
+									fr = f_findfirst(&dj, &fno, "/bin/", search_term);
+									if ((fr == FR_OK && fno.fname[0])) {
+										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
+										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);
+										break;									
 									}
+									
 									
 								}
 								

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -334,6 +334,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								FRESULT fr;
 								DIR dj;
 								FILINFO fno;
+								t_mosCommand *cmd;
 								const char *searchTermStart;
 								const char *lastSpace = strrchr(buffer, ' ');
 								const char *lastSlash = strrchr(buffer, '/');
@@ -341,12 +342,27 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								if (lastSlash == NULL && lastSpace == NULL) { //Try commands first before fatfs completion
 									
 									search_term = (char*) malloc(strlen(buffer) + 6);
+									
+									strcpy(search_term, buffer);
+									strcat(search_term, ".");
+									
+									cmd = mos_getCommand(search_term);
+									if (cmd != NULL) { //First try internal MOS commands
+										
+										printf("%s ", cmd->name + strlen(buffer));
+										strcat(buffer, cmd->name + strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);										
+										break;
+										
+									}
+									
 									strcpy(search_term, buffer);
 									strcat(search_term, "*.bin");
-									
 									fr = f_findfirst(&dj, &fno, "/mos/", search_term);
-									
-									if (fr == FR_OK && fno.fname[0]) {
+									if (fr == FR_OK && fno.fname[0]) { //Now try MOSlets
 										
 										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
 										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -338,7 +338,28 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								const char *lastSpace = strrchr(buffer, ' ');
 								const char *lastSlash = strrchr(buffer, '/');
 								
-
+								if (lastSlash == NULL && lastSpace == NULL) { //Try commands first before fatfs completion
+									
+									search_term = (char*) malloc(strlen(buffer) + 6);
+									strcpy(search_term, buffer);
+									strcat(search_term, "*.bin");
+									
+									fr = f_findfirst(&dj, &fno, "/mos/", search_term);
+									
+									if (fr == FR_OK && fno.fname[0]) {
+										
+										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
+										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);
+										break;
+										
+									}
+									
+								}
+								
 								if (lastSlash != NULL) {
 									int pathLength = 1;
 																		

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -372,6 +372,18 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 										free(search_term);
 										break;
 										
+									} else { //Otherwise try /bin/
+										
+										fr = f_findfirst(&dj, &fno, "/bin/", search_term);
+										if (!(fr == FR_OK && fno.fname[0])) break;
+										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
+										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);
+										break;									
+										
 									}
 									
 								}

--- a/src_fatfs/ffconf.h
+++ b/src_fatfs/ffconf.h
@@ -39,7 +39,7 @@
 /   3: f_lseek() function is removed in addition to 2. */
 
 
-#define FF_USE_FIND		0
+#define FF_USE_FIND		1
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 


### PR DESCRIPTION
This adds:

- Tab completion for paths/filenames and commands.
- Automatic loading and execution of non-MOSlet .bin files either from a global location (/bin/) or from within the current working directory, i.e. as for MOSlets, enter "binaryname" and if binaryname.bin is either in /bin/ or in the current working directory, it will be loaded and run.
 
This is particularly necessary now that we are getting to the point where it's simply impossible to fit some code in MOSlet space, such as Sijnstra's [excellent gunzip utility](https://github.com/sijnstra/agon-projects/tree/main/gunzip).

There are guard rails to prevent invocation of non-MOSlets from OSCLI (and therefore from within BASIC etc.) which will work for any Agon app that uses this function, preventing a user trashing running code and working RAM.

The priority order for tab resolution/execution in both cases is: built in commands, MOSlets (in /mos/), global (/bin/) .bin files, and finally .bin files in the current working directory.

The designs of these two features are necessarily interdependent with one another because of the assumptions you need to make in code, hence one PR for both otherwise unrelated features.

This is mutually exclusive with the two other PRs (now closed) for local and global non-MOSlet bin loading execution and tab completion.